### PR TITLE
Change user name formatting

### DIFF
--- a/lib/BridgedRoom.js
+++ b/lib/BridgedRoom.js
@@ -111,11 +111,11 @@ BridgedRoom.prototype.onMatrixMessage = function(message) {
   // gitter supports Markdown. We'll use that to apply a little formatting
   // to make understanding the text a little easier
   if (message.content.msgtype == 'm.emote') {
-    var text = '**' + from + '** ' + message.content.body;
+    var text = '*' + (from + ' ' + message.content.body).replace(/\*/g, '\\*') + '*';
     this._gitterRoom.sendStatus(text);
   }
   else {
-    var text = '**<' + from + '>**: ' + message.content.body;
+    var text = '`' + from + '` ' + message.content.body;
     this._gitterRoom.send(text);
   }
 };


### PR DESCRIPTION
Hopefully for the last time..

- For normal messages our Gitter users chose to use `code blocks` instead of **bold** for user name formatting.
- Make all `/me` messages *italic*.