### PR TITLE
Add ability to specify registration location with -f when running the appservice

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,8 +17,8 @@ new Cli({
         reg.setId("gitter");
         callback(reg);
     },
-    run: function(port, config) {
+    run: function(port, config, reg) {
         console.log("Matrix-side listening on port %s", port);
-        (new Main(config)).run(port);
+        (new Main(config, reg)).run(port);
     },
 }).run();

--- a/lib/Main.js
+++ b/lib/Main.js
@@ -33,7 +33,7 @@ var GITTER_LIMITER_INTERVAL = 60 * 1000 / 95;
 // There's only ever one "network ID" that we use
 var NETWORK_ID = "gitter";
 
-function Main(config) {
+function Main(config, reg) {
     var self = this;
 
     this._config = config;
@@ -55,7 +55,7 @@ function Main(config) {
     var bridge = new Bridge({
         homeserverUrl: config.matrix_homeserver,
         domain: config.matrix_user_domain,
-        registration: "gitter-registration.yaml",
+        registration: reg,
         controller: {
             onUserQuery: function(queriedUser) {
                 return {}; // auto-provision users with no additonal data


### PR DESCRIPTION
With this, you can run `node index.js -f /etc/synapse/appservice-registration-gitter.yaml ...`, and it'll work.

Before, the appservice registration file was hardcoded to be `./gitter-registration.yaml`.