### PR TITLE
Use util.inspect on objects being logged.

### DIFF
--- a/lib/Logging.js
+++ b/lib/Logging.js
@@ -39,7 +39,7 @@ class Logging {
             }));
         }
 
-        if(config.files !== undefined) {
+        if (config.files !== undefined) {
             let i = 0;
             for (let file of config.files) {
                 const filename = Object.keys(file)[0];
@@ -102,13 +102,13 @@ class LogWrapper {
         this.logger = logger;
     }
 
-    debug(...messageParts) {this._log(messageParts, 'debug')};
+    debug(...messageParts) { this._log(messageParts, 'debug') };
 
-    info(...messageParts) {this._log(messageParts, 'info')};
+    info(...messageParts) { this._log(messageParts, 'info') };
 
-    warn(...messageParts) {this._log(messageParts, 'warn')};
+    warn(...messageParts) { this._log(messageParts, 'warn') };
 
-    error(...messageParts) {this._log(messageParts, 'error')};
+    error(...messageParts) { this._log(messageParts, 'error') };
 
     _formatParts(messageParts) {
         return messageParts.map((part) => {
@@ -121,7 +121,7 @@ class LogWrapper {
 
     _log(messageParts, type) {
         messageParts = this._formatParts(messageParts);
-        if(this.logger == null) {
+        if (this.logger == null) {
             this.messages.push({type, messageParts});
             return;
         } else {

--- a/lib/Logging.js
+++ b/lib/Logging.js
@@ -39,24 +39,22 @@ class Logging {
             }));
         }
 
-        if(config.files === undefined) {
-            return;
-        }
-
-        let i = 0;
-        for (let file of config.files) {
-            const filename = Object.keys(file)[0];
-            const level = file[filename];
-            i++;
-            this.transports.push(new (winston.transports.DailyRotateFile)({
-                filename,
-                datePattern: "YYYY-MM-DD",
-                name: `logfile` + i,
-                formatter: formatterFn,
-                level,
-                timestamp: timestampFn,
-                maxFiles: config.maxFiles > 0 ? config.maxFiles : undefined
-            }));
+        if(config.files !== undefined) {
+            let i = 0;
+            for (let file of config.files) {
+                const filename = Object.keys(file)[0];
+                const level = file[filename];
+                i++;
+                this.transports.push(new (winston.transports.DailyRotateFile)({
+                    filename,
+                    datePattern: "YYYY-MM-DD",
+                    name: `logfile` + i,
+                    formatter: formatterFn,
+                    level,
+                    timestamp: timestampFn,
+                    maxFiles: config.maxFiles > 0 ? config.maxFiles : undefined
+                }));
+            }
         }
 
         this.loggers.forEach((wrapper, name) => {

--- a/lib/Logging.js
+++ b/lib/Logging.js
@@ -1,4 +1,5 @@
 const winston = require("winston");
+const util = require("util");
 require('winston-daily-rotate-file');
 
 class Logging {
@@ -111,7 +112,17 @@ class LogWrapper {
 
     error(...messageParts) {this._log(messageParts, 'error')};
 
+    _formatParts(messageParts) {
+        return messageParts.map((part) => {
+            if (typeof(part) === "object") {
+                return util.inspect(part);
+            }
+            return part;
+        });
+    }
+
     _log(messageParts, type) {
+        messageParts = this._formatParts(messageParts);
         if(this.logger == null) {
             this.messages.push([{type, messageParts}]);
             return;

--- a/lib/Logging.js
+++ b/lib/Logging.js
@@ -63,7 +63,7 @@ class Logging {
     }
 
     Get(name) {
-        if(!this.loggers.has(name)) {
+        if (!this.loggers.has(name)) {
             const wrapper = new LogWrapper()
             this.loggers.set(name, wrapper);
             /* We won't assign create and assign a logger until
@@ -122,7 +122,7 @@ class LogWrapper {
     _log(messageParts, type) {
         messageParts = this._formatParts(messageParts);
         if(this.logger == null) {
-            this.messages.push([{type, messageParts}]);
+            this.messages.push({type, messageParts});
             return;
         } else {
             /* When we first start logging, the transports


### PR DESCRIPTION
This came about because we used to use ``console.log``, which did this implicitly but winston does not. I think this is a fairly sane suggestion as long as we don't try to rapidly log lots of objects, though I don't think ``util.inspect`` has any extreme performance penalties.