### PR TITLE
Don't rejoin rooms we are in on startup.

### DIFF
--- a/lib/BridgedRoom.js
+++ b/lib/BridgedRoom.js
@@ -143,7 +143,7 @@ BridgedRoom.prototype.joinAndStart = function() {
                 throw e;
             });
         });
-    }).then(this.start.bind(this));
+    }).then((room) => this.start(room));
 };
 
 BridgedRoom.prototype.start = function(room) {

--- a/lib/BridgedRoom.js
+++ b/lib/BridgedRoom.js
@@ -2,6 +2,9 @@
 
 var Promise = require("bluebird");
 
+/* Slightly evil, but gitter doesn't export this rather useful class */
+const GitterRoom = require('node-gitter/lib/rooms.js');
+
 var retry = require("./retry");
 const log = require("./Logging.js").Get("BridgedRoom");
 
@@ -115,6 +118,7 @@ BridgedRoom.prototype.joinAndStart = function() {
         this._gitterUserId = gitterUserId;
 
         var gitterRateLimiter = this._main.getGitterRateLimiter();
+        log.info(`Joining room ${this.gitterRoomName()}`);
         return retry(() => {
             return gitterRateLimiter.next(2).then(() => {
                 this._main.incRemoteCallCounter("room.join");
@@ -139,81 +143,98 @@ BridgedRoom.prototype.joinAndStart = function() {
                 throw e;
             });
         });
-    }).then((room) => {
-        this._gitterRoom = room;
+    }).then(this.start.bind(this));
+};
 
-        this._main.incRemoteCallCounter("room.subscribe");
-        room.subscribe();
+BridgedRoom.prototype.start = function(room) {
+    log.info(`Starting room ${this.gitterRoomName()}`);
+    if(room.subscribe === undefined) {
+        /* This has been fetched from the API but isn't a room object.
+           The nde gitter API for findAll will fetch rooms as json objects,
+           but won't instance them like in join.
+           To avoid rate limiting, we have to do it ourselves :|
+        */
+        room = new GitterRoom(
+            room,
+            this._gitter,
+            this._gitter.faye,
+            this._gitter.users
+        );
+    }
 
-        room.on('chatMessages', (event) => {
-            if (!event.model) return;
-            var model = event.model;
+    this._gitterRoom = room;
 
-            var operation = event.operation;
-            if (operation !== 'create' && operation !== 'update') {
+    this._main.incRemoteCallCounter("room.subscribe");
+    room.subscribe();
+
+    room.on('chatMessages', (event) => {
+        if (!event.model) return;
+        var model = event.model;
+
+        var operation = event.operation;
+        if (operation !== 'create' && operation !== 'update') {
+            return;
+        }
+
+        var endTimer = this._main.startTimer("remote_request_seconds");
+
+        // Wait for all currently-pending send operations to complete
+        //   so we'll have the full set of message IDs
+        Promise.all(this._sendingGuards).then(() => {
+            if (model.id in this._sentMessageIds) {
+                delete this._sentMessageIds[model.id];
                 return;
             }
 
-            var endTimer = this._main.startTimer("remote_request_seconds");
+            this.onGitterMessage(model).then(
+                () => {
+                    endTimer({outcome: "success"});
+                },
+                (e) => {
+                    endTimer({outcome: "fail"});
 
-            // Wait for all currently-pending send operations to complete
-            //   so we'll have the full set of message IDs
-            Promise.all(this._sendingGuards).then(() => {
-                if (model.id in this._sentMessageIds) {
-                    delete this._sentMessageIds[model.id];
-                    return;
+                    log.warn("Failed: ", e);
                 }
-
-                this.onGitterMessage(model).then(
-                    () => {
-                        endTimer({outcome: "success"});
-                    },
-                    (e) => {
-                        endTimer({outcome: "fail"});
-
-                        log.warn("Failed: ", e);
-                    }
-                );
-            });
+            );
         });
+    });
 
-        room.on('users', (event) => {
-            if (!event.model) return;
-            var model = event.model;
+    room.on('users', (event) => {
+        if (!event.model) return;
+        var model = event.model;
 
-            // TODO(paul): investigate if we get 'update' events on changes of
-            //   displayname/avatar
+        // TODO(paul): investigate if we get 'update' events on changes of
+        //   displayname/avatar
 
-            var operation = event.operation;
-            if (operation === 'remove') {
-                this._main.getGitterUser(model.id).then((user) => {
-                    if (user) {
-                        this.onGitterUserLeft(user);
-                    }
-                });
+        var operation = event.operation;
+        if (operation === 'remove') {
+            this._main.getGitterUser(model.id).then((user) => {
+                if (user) {
+                    this.onGitterUserLeft(user);
+                }
+            });
+        }
+    });
+
+    this._gitterRealtime.subscribe("/v1/rooms/" + room.id, (message) => {
+        this._main.getGitterUser(message.userId).then((user) => {
+            if (this._enablePresence && user) {
+                user.setRoomPresence(room.id, message.status == 'in');
             }
         });
-
-        this._gitterRealtime.subscribe("/v1/rooms/" + room.id, (message) => {
-            this._main.getGitterUser(message.userId).then((user) => {
-                if (this._enablePresence && user) {
-                    user.setRoomPresence(room.id, message.status == 'in');
-                }
-            });
-        });
-
-        this._cleanupIntervalId = setInterval(() => {
-            var ids = this._sentMessageIds;
-            var limit = Date.now() - STALE_ID_LIMIT;
-
-            // Delete any stale sent message IDs older than an hour
-            Object.keys(ids).forEach((id) => {
-                if (ids[id] < limit) {
-                    delete ids[id];
-                }
-            });
-        }, STALE_CLEANUP_INTERVAL);
     });
+
+    this._cleanupIntervalId = setInterval(() => {
+        var ids = this._sentMessageIds;
+        var limit = Date.now() - STALE_ID_LIMIT;
+
+        // Delete any stale sent message IDs older than an hour
+        Object.keys(ids).forEach((id) => {
+            if (ids[id] < limit) {
+                delete ids[id];
+            }
+        });
+    }, STALE_CLEANUP_INTERVAL);
 };
 
 BridgedRoom.prototype.stopAndLeave = function() {

--- a/lib/Main.js
+++ b/lib/Main.js
@@ -50,6 +50,8 @@ function Main(config) {
 
     this._gitterRateLimiter = new RateLimiter(GITTER_LIMITER_INTERVAL);
 
+    this._gitterJoinedRooms = [];
+
     // TODO(paul): ugh. this.getBotIntent() doesn't work before .run time
     // So we can't create the StateLookup instance yet
     this._stateStorage = null;
@@ -789,6 +791,9 @@ Main.prototype.makeMatrixRoom = function(opts) {
 
 Main.prototype.run = function(port) {
     var bridge = this._bridge;
+
+    const promise = this._gitter.rooms.findAll();
+    console.log(promise);
 
     bridge.loadDatabases().then(() => {
         return this.getRoomStore().select({

--- a/lib/Main.js
+++ b/lib/Main.js
@@ -788,9 +788,10 @@ Main.prototype.makeMatrixRoom = function(opts) {
 
 Main.prototype.run = function(port) {
     var bridge = this._bridge;
+    // Catch here so we don't spam out failures for each entry.
     const promiseAllRooms = this._gitter.rooms.findAll().catch((err) => {
         log.error("Could not fetch all joined gitter rooms from gitter!", err);
-        return [];
+        return []; // We still want to continue on failure
     });
 
     bridge.loadDatabases().then(() => {
@@ -814,8 +815,8 @@ Main.prototype.run = function(port) {
                 }
                 this._bridgedRoomsByMatrixId[matrix_id] = room;
                 this._stateStorage.trackRoom(matrix_id);
-                return promiseAllRooms.then((_allRooms) => {
-                    const gitterRoom = _allRooms.find((_room) => _room.name === remote_id);
+                return promiseAllRooms.then((allRooms) => {
+                    const gitterRoom = allRooms.find((joinedRoom) => joinedRoom.name === remote_id);
                     if (gitterRoom !== undefined) {
                         return room.start(gitterRoom);
                     } else {

--- a/lib/Main.js
+++ b/lib/Main.js
@@ -788,7 +788,10 @@ Main.prototype.makeMatrixRoom = function(opts) {
 
 Main.prototype.run = function(port) {
     var bridge = this._bridge;
-    // Catch here so we don't spam out failures for each entry.
+    /* We run this query findAll first, and let it run in parallel until
+       we need the room list later.
+       Catch here so we don't spam out failures for each entry.
+    */
     const promiseAllRooms = this._gitter.rooms.findAll().catch((err) => {
         log.error("Could not fetch all joined gitter rooms from gitter!", err);
         return []; // We still want to continue on failure

--- a/lib/Main.js
+++ b/lib/Main.js
@@ -49,9 +49,6 @@ function Main(config) {
     this._gitterRealtime = new GitterRealtimeClient.RealtimeClient({token: config.gitter_api_key});
 
     this._gitterRateLimiter = new RateLimiter(GITTER_LIMITER_INTERVAL);
-
-    this._gitterJoinedRooms = [];
-
     // TODO(paul): ugh. this.getBotIntent() doesn't work before .run time
     // So we can't create the StateLookup instance yet
     this._stateStorage = null;
@@ -791,9 +788,10 @@ Main.prototype.makeMatrixRoom = function(opts) {
 
 Main.prototype.run = function(port) {
     var bridge = this._bridge;
-
-    const promise = this._gitter.rooms.findAll();
-    console.log(promise);
+    const promiseAllRooms = this._gitter.rooms.findAll().catch((err) => {
+        log.error("Could not fetch all joined gitter rooms from gitter!", err);
+        return [];
+    });
 
     bridge.loadDatabases().then(() => {
         return this.getRoomStore().select({
@@ -816,8 +814,14 @@ Main.prototype.run = function(port) {
                 }
                 this._bridgedRoomsByMatrixId[matrix_id] = room;
                 this._stateStorage.trackRoom(matrix_id);
-
-                return room.joinAndStart();
+                return promiseAllRooms.then((_allRooms) => {
+                    const gitterRoom = _allRooms.find((_room) => _room.name === remote_id);
+                    if (gitterRoom !== undefined) {
+                        return room.start(gitterRoom);
+                    } else {
+                        return room.joinAndStart();
+                    }
+                });
             }).then(() => {
                 log.info((data.portal ? "PORTAL " : "LINKED ") +
                             matrix_id + " to " + remote_id);


### PR DESCRIPTION
The reason for this is we are allowed about 100 calls per minute and on startup we currently hammer the API with calls to join rooms we are in. This PR fetches the list and then skips the join logic. 

This PR isn't as elegant as I'd like, e.g. the only way you can get a subscribable room object from ``node-gitter`` is by making an API call to get a single room, fetching the list doesn't give us proper objects. Therefore I am fetching the Room class straight from the source files and passing in the parameters myself. This is obviously evil, but it's that or making tons of unnecessary calls.