### PR TITLE
Anti-Hellban

### DIFF
--- a/lib/GitterGhost.js
+++ b/lib/GitterGhost.js
@@ -50,6 +50,13 @@ GitterGhost.prototype._getRoom = function(roomName) {
 };
 
 GitterGhost.prototype._couldBeBanned = function(text) {
+    /*
+        Gitter bans users for sending too many messages with the same has in a set period (12 hours).
+        It's rather impractical, but the best way to deal with this is to pre-empt them and check the 
+        thesholds ourselves by storing all the hashes locally. Gitter also do not make any distinction
+        about the destination room where the message may be sent, so we must apply these limits globally
+        which is a bit lame.
+     */
     const hash = crypto.createHash('md5').update(text).digest('hex');
     // Lifted from https://gitlab.com/gitlab-org/gitter/webapp/blob/develop/modules/spam-detection/lib/duplicate-chat-detector.js#L26
     let threshold = 8;

--- a/lib/GitterGhost.js
+++ b/lib/GitterGhost.js
@@ -13,8 +13,8 @@ function GitterGhost(opts) {
     this._rateLimiter = opts.rateLimiter;
     this._messageDuplicationCount = {
         // msg => {
-        //    time
-        //    count 
+        //    time: number
+        //    count: number
         //}
     };
 

--- a/lib/GitterGhost.js
+++ b/lib/GitterGhost.js
@@ -1,10 +1,32 @@
 "use strict";
+const crypto = require('crypto');
+
+const LASTMESSAGE_TTL_MS = 12 * 60 * 60 * 1000;
+const LASTMESSAGE_REAP_INTERVAL = 60 * 1000;
+
+const log = require("./Logging.js").Get("GitterGhost");
 
 function GitterGhost(opts) {
     this._main = opts.main;
     this._gitter = opts.gitter;
     this._is_puppet = opts.is_puppet || false;
     this._rateLimiter = opts.rateLimiter;
+    this._messageDuplicationCount = {
+        // msg => {
+        //    time
+        //    count 
+        //}
+    };
+
+    // Do this regularly to reclaim memory.
+    setInterval(() => {
+        Object.keys(this._messageDuplicationCount).forEach((text) => {
+            const d = this._messageDuplicationCount[text];
+            if (d.time + LASTMESSAGE_TTL_MS < Date.now) {
+                delete this._messageDuplicationCount[text];
+            }
+        });
+    }, LASTMESSAGE_REAP_INTERVAL);
 
     this._roomsByName = {};
 }
@@ -27,7 +49,37 @@ GitterGhost.prototype._getRoom = function(roomName) {
     });
 };
 
+GitterGhost.prototype._couldBeBanned = function(text) {
+    const hash = crypto.createHash('md5').update(text).digest('hex');
+    // Lifted from https://gitlab.com/gitlab-org/gitter/webapp/blob/develop/modules/spam-detection/lib/duplicate-chat-detector.js#L26
+    let threshold = 8;
+    if (text.length < 10) {
+        threshold = 80;
+    }
+    else if (text.length < 20) {
+        threshold = 16;
+    }
+
+    const dupes = this._messageDuplicationCount[hash];
+    if (!dupes || dupes.time + LASTMESSAGE_TTL_MS < Date.now) {
+        this._messageDuplicationCount[hash] = {
+            time: Date.now(),
+            count: 1,
+        };
+    }
+    else if (dupes.count > threshold) {
+        return true;
+    } else {
+        this._messageDuplicationCount[hash].count++;
+        return dupes.count > threshold;
+    }
+}
+
 GitterGhost.prototype.send = function(roomName, text) {
+    if (this._couldBeBanned(text)) {
+        log.warn(`Ghost has hit local anti-spam threshold (in room ${roomName})`);
+        throw Error("Not sending message, ghost is above ban threshold for spam");
+    }
     return this._getRoom(roomName).then((room) => {
         return this._rateLimiter.next().then(() => {
             this._main.incRemoteCallCounter("room.send");


### PR DESCRIPTION
Gitter sometimes bans us for spamming too much, and it's gotten worse recently. This PR makes it so that the bridge tracks the thresholds for messages and drops them to avoid triggering a ban.
Fixes https://github.com/matrix-org/matrix-appservice-gitter/issues/61