### PR TITLE
Add missing portal config opts to config sample/schema 

### DIFF
--- a/config/gitter-config-sample.yaml
+++ b/config/gitter-config-sample.yaml
@@ -28,3 +28,7 @@ logging:
     files:
         -   "debug.log": "debug"
     maxFiles: 1
+
+
+enable_portals: true
+alias_template: "gitter_${ROOM}"

--- a/config/gitter-config-sample.yaml
+++ b/config/gitter-config-sample.yaml
@@ -29,6 +29,5 @@ logging:
         -   "debug.log": "debug"
     maxFiles: 1
 
-
-enable_portals: true
+enable_portals: false
 alias_template: "gitter_${ROOM}"

--- a/config/gitter-config-schema.yaml
+++ b/config/gitter-config-schema.yaml
@@ -30,6 +30,10 @@ properties:
     type: boolean
   enable_metrics:
     type: boolean
+  enable_portals:
+    type: boolean
+  alias_template:
+    type: string
   logging:
     properties:
       console:

--- a/lib/Main.js
+++ b/lib/Main.js
@@ -38,6 +38,12 @@ function Main(config, registration) {
 
     this._config = config;
 
+    if (config.enable_portals && !config.alias_template) {
+        throw Error("enable_portals is true but no alias_template was given. Please define one in the config!");
+    }
+
+    log.info(`Portal room requests will be ${config.enable_portals ? "HANDLED" : "IGNORED"}`);
+
     this.homeserver = config.matrix_homeserver;
     this.media_url = config.matrix_external_url || this.homeserver;
 
@@ -868,11 +874,15 @@ Main.prototype.onAliasQuery = function(alias, localpart) {
     log.debug("onAliasQuery:", alias, localpart);
     if (!this.alias_template) return null;
 
-    var result = this.alias_template.matchId(alias);
-    if (!result) return null;
+    const result = this.alias_template.matchId(alias);
+    console.log(this.alias_template);
+    if (!result) {
+        log.warn("Alias did not match template");
+        return null;
+    };
 
     // unescape the =2F encoding of '/'
-    var gitterName = result.ROOM.replace(/=2F/i, "/");
+    const gitterName = result.ROOM.replace(/=2F/i, "/");
 
     return this.actionMakePortal(gitterName).then((result) => {
         return result.matrix_room_id;


### PR DESCRIPTION
Some of the config options for portal rooms were missing from the sample config, which is quite annoying if you are trying to set up the bridge for the first time.