### PR TITLE
Load schema using absolute path

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,11 +3,12 @@ const AppServiceRegistration = require("matrix-appservice-bridge").AppServiceReg
 const Main = require("./lib/Main");
 const ConfigureLogging = require("./lib/Logging.js").Configure;
 const log = require("./lib/Logging.js").Get("index.js");
+const path = require("path");
 
 new Cli({
     registrationPath: "gitter-registration.yaml",
     bridgeConfig: {
-        schema: "config/gitter-config-schema.yaml",
+        schema: path.join(__dirname, "config/gitter-config-schema.yaml"),
     },
     generateRegistration: function(reg, callback) {
         reg.setHomeserverToken(AppServiceRegistration.generateToken());


### PR DESCRIPTION
When the app was started from directory other than the one containing `index.js`, following error was encountered:

```
fs.js:114
    throw err;
    ^
Error: ENOENT: no such file or directory, open 'config/gitter-config-schema.yaml'
    at Object.openSync (fs.js:443:3)
    at Object.readFileSync (fs.js:343:35)
    at ConfigValidator._loadFromFile (/nix/store/p4yzzpxycpqsf7ihprk4ym38jk1f5fzr-node_matrix-appservice-gitter-0.1.1/lib/node_modules/matrix-appservice-gitter/node_modules/matrix-appservice-bridge/lib/components/config-validator.js:63:29)
    at new ConfigValidator (/nix/store/p4yzzpxycpqsf7ihprk4ym38jk1f5fzr-node_matrix-appservice-gitter-0.1.1/lib/node_modules/matrix-appservice-gitter/node_modules/matrix-appservice-bridge/lib/components/config-validator.js:29:28)
    at Cli._loadConfig (/nix/store/p4yzzpxycpqsf7ihprk4ym38jk1f5fzr-node_matrix-appservice-gitter-0.1.1/lib/node_modules/matrix-appservice-gitter/node_modules/matrix-appservice-bridge/lib/components/cli.js:159:21)
    at Cli._assignConfigFile (/nix/store/p4yzzpxycpqsf7ihprk4ym38jk1f5fzr-node_matrix-appservice-gitter-0.1.1/lib/node_modules/matrix-appservice-gitter/node_modules/matrix-appservice-bridge/lib/components/cli.js:144:23)
    at Cli.run (/nix/store/p4yzzpxycpqsf7ihprk4ym38jk1f5fzr-node_matrix-appservice-gitter-0.1.1/lib/node_modules/matrix-appservice-gitter/node_modules/matrix-appservice-bridge/lib/components/cli.js:139:10)
    at Object.<anonymous> (/nix/store/p4yzzpxycpqsf7ihprk4ym38jk1f5fzr-node_matrix-appservice-gitter-0.1.1/lib/node_modules/matrix-appservice-gitter/index.js:30:4)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:831:12)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:623:3)
```