### PR TITLE
Migration script for portal rooms to gitter.im

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "node-gitter": "^2.1.0",
     "request-promise": "^3",
     "winston": "2.4.2",
-    "winston-daily-rotate-file": "^3.2.1"
+    "winston-daily-rotate-file": "^3.2.1",
+    "matrix-bot-sdk": "^0.5.8"
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.30",

--- a/scripts/migrate-portals.js
+++ b/scripts/migrate-portals.js
@@ -96,10 +96,13 @@ rl.on('close', async () => {
                 },
                 "users_default": 0            
             });
-            if (joined) {
-                console.log("Parting joined room");
-                await client.leaveRoom(targetRoomId);
+            const canonicalAlias = await client.getPublishedAlias(oldMatrixRoomId);
+            if (canonicalAlias) {
+                console.log("Removing old alias");
+                await client.deleteRoomAlias(canonicalAlias);
             }
+            // In case it followed.
+            await client.leaveRoom(targetRoomId);
         }
         await fs.promises.writeFile('checkpoint.txt', `${index}`, 'utf-8');
         index++;

--- a/scripts/migrate-portals.js
+++ b/scripts/migrate-portals.js
@@ -52,7 +52,7 @@ rl.on('close', async () => {
             continue;
         }
         console.log("Joining new room...");
-        const targetRoomId = await clientStoner.joinRoom(alias);
+        const targetRoomId = await client.joinRoom(alias);
         console.log(`${gitterRoomId} -> ${targetRoomId} (from: ${oldMatrixRoomId})`);
         if (!targetRoomId) {
             console.log(`No target room for ${gitterRoomId}!`);

--- a/scripts/migrate-portals.js
+++ b/scripts/migrate-portals.js
@@ -51,6 +51,13 @@ async function migrateRoom({gitterRoomId, oldMatrixRoomId, alias}) {
             console.log(`${gitterRoomId} -> does not exist anymore. Not bridging`);
             return;
         }
+        if (ex.body && ex.body.errcode === 'M_LIMIT_EXCEEDED') {
+            console.log(`${gitterRoomId} -> rate limit`);
+            await new Promise((r) => setTimeout(r, ex.body.retry_after_ms + 100));
+            targetRoomId = await client.joinRoom(alias);
+            return;
+        }
+        throw ex;
     }
     console.log(`${gitterRoomId} -> ${targetRoomId} (from: ${oldMatrixRoomId})`);
     if (!targetRoomId) {

--- a/scripts/migrate-portals.js
+++ b/scripts/migrate-portals.js
@@ -35,26 +35,6 @@ rl.on('line', (line) => {
     portalRooms.push({gitterRoomId, oldMatrixRoomId, alias});
 });
 
-async function getNewRoomId(alias) {
-    try {
-        const targetRoomId = await client.resolveRoom(alias);
-        return { targetRoomId, joined: false };
-    } catch (ex) {
-        if (dryRun) {
-            return {
-                targetRoomId: '!noroomyet:gitter.im',
-                joined: false,
-            };
-        }
-        console.log("Joining new gitter room...");
-        await new Promise((r) => setTimeout(r, 5000)); // Joins cost more in rate limits
-        return {
-            targetRoomId: await client.joinRoom(alias),
-            joined: true,
-        };
-    }
-}
-
 rl.on('close', async () => {
     let index = 0;
     try {
@@ -65,7 +45,7 @@ rl.on('close', async () => {
     console.log(`Starting from index ${index}`);
     for (const {gitterRoomId, oldMatrixRoomId, alias} of portalRooms.slice(index)) {
         await new Promise((r) => setTimeout(r, 3000));
-        const {targetRoomId, joined} = await getNewRoomId(alias);
+        const targetRoomId = await client.joinRoom(alias);
         console.log(`${gitterRoomId} -> ${targetRoomId} (from: ${oldMatrixRoomId})`);
         if (!targetRoomId) {
             console.log(`No target room for ${gitterRoomId}!`);

--- a/scripts/migrate-portals.js
+++ b/scripts/migrate-portals.js
@@ -99,7 +99,7 @@ rl.on('close', async () => {
             await new Promise((r) => setTimeout(r, 3000));
             await migrateRoom(entry);
         } catch (ex) {
-            console.error(`Failed to migrate`, entry, ex);
+            console.error(`Failed to migrate`, entry, ex.message || ex.statusCode || ex.body || "No Error");
         }
         await fs.promises.writeFile('checkpoint.txt', `${index}`, 'utf-8');
         index++;

--- a/scripts/migrate-portals.js
+++ b/scripts/migrate-portals.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const readline = require('readline');
+const { MatrixClient, LogService } = require('matrix-bot-sdk');
+
+LogService.setLevel('ERROR');
+
+const client = new MatrixClient(process.env.MATRIX_URL, process.env.MATRIX_AT);
+
+const dryRun = process.env.DRY_RUN ? process.env.DRY_RUN === 'true' : true;
+
+const rl = readline.createInterface({
+    input: fs.createReadStream(process.env.ROOM_STORE || './room-store.db'),
+    output: process.stdout,
+    terminal: false
+});
+
+let portalRooms = [];
+
+rl.on('line', (line) => {
+    const roomEntry = JSON.parse(line);
+    if (!roomEntry.matrix_id) {
+        return;
+    }
+    if (!roomEntry?.data?.portal) {
+        return;
+    }
+    const gitterRoomId = roomEntry.remote_id;
+    const oldMatrixRoomId = roomEntry.matrix_id;
+    const localpart = gitterRoomId.replace('/', '_');
+    const alias = `#${localpart}:gitter.im`;
+    portalRooms.push({gitterRoomId, oldMatrixRoomId, alias});
+});
+
+async function getNewRoomId(alias) {
+    try {
+        const targetRoomId = await client.resolveRoom(alias);
+        return { targetRoomId, joined: false };
+    } catch (ex) {
+        if (dryRun) {
+            return {
+                targetRoomId: '!noroomyet:gitter.im',
+                joined: false,
+            };
+        }
+        await new Promise((r) => setTimeout(r, 5000)); // Joins cost more in rate limits
+        return {
+            targetRoomId: await client.joinRoom(alias),
+            joined: true,
+        };
+    }
+}
+
+rl.on('close', async () => {
+    let index = 0;
+    try {
+        index = parseInt(await fs.promises.readFile('checkpoint.txt', 'utf-8'), 10);
+    } catch (ex) {
+        console.log(`Failed to fetch index, starting from the beginning`);
+    }
+    console.log(`Starting from index ${index}`);
+    for (const {gitterRoomId, oldMatrixRoomId, alias} of portalRooms.slice(index)) {
+        await new Promise((r) => setTimeout(r, 3000));
+        const {targetRoomId, joined} = await getNewRoomId(alias);
+        console.log(`${gitterRoomId} -> ${targetRoomId} (from: ${oldMatrixRoomId})`);
+        if (!targetRoomId) {
+            console.log(`No target room for ${gitterRoomId}!`);
+        }
+        if (!dryRun) {
+            await client.sendStateEvent(gitterRoomId, 'm.room.tombstone', '', {
+                body: `The matrix.org Gitter bridge has been discontinued. You can view this channel on the new bridge over at ${alias}`,
+                replacement_room: targetRoomId,
+            });
+            // Disallow people from talking, should provide incentive to join the new room
+            await client.sendStateEvent(gitterRoomId, 'm.power_levels.tombstone', '', {
+                "ban": 50,
+                "events": {
+                    "m.room.avatar": 50,
+                    "m.room.canonical_alias": 50,
+                    "m.room.history_visibility": 100,
+                    "m.room.name": 50,
+                    "m.room.power_levels": 100
+                },
+                "events_default": 100,
+                "invite": 0,
+                "kick": 50,
+                "redact": 50,
+                "state_default": 50,
+                "users": {
+                    "@gitterbot:matrix.org": 100
+                },
+                "users_default": 0            
+            });
+            if (joined) {
+                await client.leaveRoom(targetRoomId);
+            }    
+        }
+        await fs.promises.writeFile('checkpoint.txt', `${index}`, 'utf-8');
+        index++;
+    }
+})

--- a/scripts/migrate-portals.js
+++ b/scripts/migrate-portals.js
@@ -54,7 +54,6 @@ async function migrateRoom({gitterRoomId, oldMatrixRoomId, alias}) {
             console.log(`${gitterRoomId} -> rate limit`);
             await new Promise((r) => setTimeout(r, ex.body.retry_after_ms + 100));
             targetRoomId = await client.joinRoom(alias);
-            return;
         } else {
             throw ex;
         }

--- a/scripts/migrate-portals.js
+++ b/scripts/migrate-portals.js
@@ -52,7 +52,15 @@ rl.on('close', async () => {
             continue;
         }
         console.log("Joining new room...");
-        const targetRoomId = await client.joinRoom(alias);
+        let targetRoomId;
+        try {
+            targetRoomId = await client.joinRoom(alias);
+        } catch (ex) {
+            if (ex.body && ex.body.errcode === 'M_NOT_FOUND') {
+                console.log(`${gitterRoomId} -> does not exist anymore. Not bridging`);
+                continue;
+            }
+        }
         console.log(`${gitterRoomId} -> ${targetRoomId} (from: ${oldMatrixRoomId})`);
         if (!targetRoomId) {
             console.log(`No target room for ${gitterRoomId}!`);

--- a/scripts/migrate-portals.js
+++ b/scripts/migrate-portals.js
@@ -22,7 +22,7 @@ rl.on('line', (line) => {
     if (!roomEntry.matrix_id) {
         return;
     }
-    if (!roomEntry?.data?.portal) {
+    if (!roomEntry || !roomEntry.data || !roomEntry.data.portal) {
         return;
     }
     const gitterRoomId = roomEntry.remote_id;

--- a/scripts/migrate-portals.js
+++ b/scripts/migrate-portals.js
@@ -32,6 +32,26 @@ rl.on('line', (line) => {
     portalRooms.push({gitterRoomId, oldMatrixRoomId, alias});
 });
 
+async function getNewRoomId(alias) {
+    try {
+        const targetRoomId = await client.resolveRoom(alias);
+        return { targetRoomId, joined: false };
+    } catch (ex) {
+        if (dryRun) {
+            return {
+                targetRoomId: '!noroomyet:gitter.im',
+                joined: false,
+            };
+        }
+        console.log("Joining new gitter room...");
+        await new Promise((r) => setTimeout(r, 5000)); // Joins cost more in rate limits
+        return {
+            targetRoomId: await client.joinRoom(alias),
+            joined: true,
+        };
+    }
+}
+
 rl.on('close', async () => {
     let index = 0;
     try {
@@ -41,21 +61,23 @@ rl.on('close', async () => {
     }
     console.log(`Starting from index ${index}`);
     for (const {gitterRoomId, oldMatrixRoomId, alias} of portalRooms.slice(index)) {
-        await new Promise((r) => setTimeout(r, 4000));
-        const targetRoomId = await client.joinRoom(alias);
+        await new Promise((r) => setTimeout(r, 3000));
+        const {targetRoomId, joined} = await getNewRoomId(alias);
         console.log(`${gitterRoomId} -> ${targetRoomId} (from: ${oldMatrixRoomId})`);
         if (!targetRoomId) {
             console.log(`No target room for ${gitterRoomId}!`);
         }
         if (!dryRun) {
+            console.log("Joining new room...");
+            await client.joinRoom(alias)
             console.log("Add tombstone...");
-            await client.sendStateEvent(gitterRoomId, 'm.room.tombstone', '', {
+            await client.sendStateEvent(oldMatrixRoomId, 'm.room.tombstone', '', {
                 body: `The matrix.org Gitter bridge has been discontinued. You can view this channel on the new bridge over at ${alias}`,
                 replacement_room: targetRoomId,
             });
             console.log("Sending power level update");
             // Disallow people from talking, should provide incentive to join the new room
-            await client.sendStateEvent(gitterRoomId, 'm.room.power_levels', '', {
+            await client.sendStateEvent(oldMatrixRoomId, 'm.room.power_levels', '', {
                 "ban": 50,
                 "events": {
                     "m.room.avatar": 50,
@@ -74,8 +96,10 @@ rl.on('close', async () => {
                 },
                 "users_default": 0            
             });
-            console.log("Parting joined room");
-            await client.leaveRoom(targetRoomId);
+            if (joined) {
+                console.log("Parting joined room");
+                await client.leaveRoom(targetRoomId);
+            }
         }
         await fs.promises.writeFile('checkpoint.txt', `${index}`, 'utf-8');
         index++;

--- a/scripts/migrate-portals.js
+++ b/scripts/migrate-portals.js
@@ -50,14 +50,14 @@ async function migrateRoom({gitterRoomId, oldMatrixRoomId, alias}) {
         if (ex.body && ex.body.errcode === 'M_NOT_FOUND') {
             console.log(`${gitterRoomId} -> does not exist anymore. Not bridging`);
             return;
-        }
-        if (ex.body && ex.body.errcode === 'M_LIMIT_EXCEEDED') {
+        } else if (ex.body && ex.body.errcode === 'M_LIMIT_EXCEEDED') {
             console.log(`${gitterRoomId} -> rate limit`);
             await new Promise((r) => setTimeout(r, ex.body.retry_after_ms + 100));
             targetRoomId = await client.joinRoom(alias);
             return;
+        } else {
+            throw ex;
         }
-        throw ex;
     }
     console.log(`${gitterRoomId} -> ${targetRoomId} (from: ${oldMatrixRoomId})`);
     if (!targetRoomId) {

--- a/scripts/migrate-portals.js
+++ b/scripts/migrate-portals.js
@@ -65,7 +65,7 @@ async function migrateRoom({gitterRoomId, oldMatrixRoomId, alias}) {
         ...powerLevels,
         "events_default": 100,    
     });
-    await client.sendMessage(oldMatrixRoomId, `The matrix.org Gitter bridge has been discontinued. You can view this channel on the new bridge over at ${alias}`);
+    await client.sendText(oldMatrixRoomId, `The matrix.org Gitter bridge has been discontinued. You can view this channel on the new bridge over at ${alias}`);
     console.log("Add tombstone...");
     await client.sendStateEvent(oldMatrixRoomId, 'm.room.tombstone', '', {
         body: `The matrix.org Gitter bridge has been discontinued. You can view this channel on the new bridge over at ${alias}`,

--- a/scripts/migrate-portals.js
+++ b/scripts/migrate-portals.js
@@ -32,26 +32,6 @@ rl.on('line', (line) => {
     portalRooms.push({gitterRoomId, oldMatrixRoomId, alias});
 });
 
-async function getNewRoomId(alias) {
-    try {
-        const targetRoomId = await client.resolveRoom(alias);
-        return { targetRoomId, joined: false };
-    } catch (ex) {
-        if (dryRun) {
-            return {
-                targetRoomId: '!noroomyet:gitter.im',
-                joined: false,
-            };
-        }
-        console.log("Joining new gitter room...");
-        await new Promise((r) => setTimeout(r, 5000)); // Joins cost more in rate limits
-        return {
-            targetRoomId: await client.joinRoom(alias),
-            joined: true,
-        };
-    }
-}
-
 rl.on('close', async () => {
     let index = 0;
     try {
@@ -61,8 +41,8 @@ rl.on('close', async () => {
     }
     console.log(`Starting from index ${index}`);
     for (const {gitterRoomId, oldMatrixRoomId, alias} of portalRooms.slice(index)) {
-        await new Promise((r) => setTimeout(r, 3000));
-        const {targetRoomId, joined} = await getNewRoomId(alias);
+        await new Promise((r) => setTimeout(r, 4000));
+        const targetRoomId = await client.joinRoom(alias);
         console.log(`${gitterRoomId} -> ${targetRoomId} (from: ${oldMatrixRoomId})`);
         if (!targetRoomId) {
             console.log(`No target room for ${gitterRoomId}!`);
@@ -94,10 +74,8 @@ rl.on('close', async () => {
                 },
                 "users_default": 0            
             });
-            if (joined) {
-                console.log("Parting joined room");
-                await client.leaveRoom(targetRoomId);
-            }
+            console.log("Parting joined room");
+            await client.leaveRoom(targetRoomId);
         }
         await fs.promises.writeFile('checkpoint.txt', `${index}`, 'utf-8');
         index++;

--- a/scripts/migrate-portals.js
+++ b/scripts/migrate-portals.js
@@ -43,6 +43,7 @@ async function getNewRoomId(alias) {
                 joined: false,
             };
         }
+        console.log("Joining new gitter room...");
         await new Promise((r) => setTimeout(r, 5000)); // Joins cost more in rate limits
         return {
             targetRoomId: await client.joinRoom(alias),
@@ -67,12 +68,14 @@ rl.on('close', async () => {
             console.log(`No target room for ${gitterRoomId}!`);
         }
         if (!dryRun) {
+            console.log("Add tombstone...");
             await client.sendStateEvent(gitterRoomId, 'm.room.tombstone', '', {
                 body: `The matrix.org Gitter bridge has been discontinued. You can view this channel on the new bridge over at ${alias}`,
                 replacement_room: targetRoomId,
             });
+            console.log("Sending power level update");
             // Disallow people from talking, should provide incentive to join the new room
-            await client.sendStateEvent(gitterRoomId, 'm.power_levels.tombstone', '', {
+            await client.sendStateEvent(gitterRoomId, 'm.room.power_levels', '', {
                 "ban": 50,
                 "events": {
                     "m.room.avatar": 50,
@@ -92,8 +95,9 @@ rl.on('close', async () => {
                 "users_default": 0            
             });
             if (joined) {
+                console.log("Parting joined room");
                 await client.leaveRoom(targetRoomId);
-            }    
+            }
         }
         await fs.promises.writeFile('checkpoint.txt', `${index}`, 'utf-8');
         index++;

--- a/scripts/migrate-portals.js
+++ b/scripts/migrate-portals.js
@@ -22,6 +22,9 @@ rl.on('line', (line) => {
     if (!roomEntry.matrix_id) {
         return;
     }
+    if (!roomEntry.matrix_id.endsWith('matrix.org')) {
+        return;
+    }
     if (!roomEntry || !roomEntry.data || !roomEntry.data.portal) {
         return;
     }


### PR DESCRIPTION
This script basically iterates over the `room-store.db` file, finds the gitter room for the new room, and "upgrades" the existing room to it. You'll notice we use the tombstone event to link to the new room, but do not perform an upgrade using the Matrix C-S api as that would create a new room.

We also mute the old room to encourage folks to migrate.

Part of:

 - https://github.com/matrix-org/matrix-appservice-gitter/issues/104
 - https://gitlab.com/gitterHQ/webapp/-/issues/2675

![](https://user-images.githubusercontent.com/558581/101806200-4e3f0800-3ad9-11eb-8458-3a8b2357c880.gif)
